### PR TITLE
Add skip-backup param to wp attachment command

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,13 @@ $ wp image-optimize wp-includes
 
 ### Restoring the originals
 
-This command backs up the full sized images before optimizing attachments. If you want to restore them:
+This command backs up the full sized images before optimizing attachments, use `--skip-backup` to skip backup file generation (WARNING: with `--skip-backup` the original images will be gone forever). If you want to restore them:
 
 ```bash
-# optimize
+# optimize **with backup**
 $ wp image-optimize attachment 123
+# optimize **without backup**
+$ wp image-optimize attachment 123 --skip-backup
 
 # restore the full sized image
 $ wp image-optimize restore 123

--- a/src/CLI/Commands/AttachmentCommand.php
+++ b/src/CLI/Commands/AttachmentCommand.php
@@ -58,13 +58,15 @@ class AttachmentCommand
         $fileSystem = new Filesystem();
         $logger = LoggerFactory::create();
 
-        if (!$skipBackup)
+        if (true !== $skipBackup) {
             $backupOperation = $this->createBackupOperation($repo, $fileSystem, $logger);
+        }
 
         $optimizeOperation = $this->createOptimizeOperation($repo, $fileSystem, $logger);
 
-        if (!$skipBackup)
+        if (true !== $skipBackup) {
             $backupOperation->execute(...$ids);
+        }
 
         $optimizeOperation->execute(...$ids);
     }

--- a/src/CLI/Commands/AttachmentCommand.php
+++ b/src/CLI/Commands/AttachmentCommand.php
@@ -23,17 +23,30 @@ class AttachmentCommand
      *
      * <id>...
      * : The IDs of attachments to optimize.
-     *
+     * 
+     * [--skip-backup]
+     * : Skip generation of backup file.
+     * ---
+     * default: false
+     * ---
+     * 
      * ## EXAMPLES
      *
-     *     # Optimize attachment ID: 123
+     *     # Optimize attachment ID: 123 (with backup)
      *     $ wp image-optimize attachment 123
+     * 
+     *     # Optimize attachment ID: 123 --skip-backup (without backup)
+     *     $ wp image-optimize attachment 123 --skip-backup
      *
-     *     # Optimize multiple attachments
+     *     # Optimize multiple attachments (with backup)
      *     $ wp image-optimize attachment 123 223 323
+     *
+     *     # Optimize multiple attachments (without backup)
+     *     $ wp image-optimize attachment 123 223 323 --skip-backup
      */
     public function __invoke($args, $_assocArgs): void
     {
+        $skipBackup = (bool) $_assocArgs['skip-backup'];
         $ids = array_map(function (string $id): ?int {
             return is_numeric($id)
                 ? (int) $id
@@ -45,10 +58,14 @@ class AttachmentCommand
         $fileSystem = new Filesystem();
         $logger = LoggerFactory::create();
 
-        $backupOperation = $this->createBackupOperation($repo, $fileSystem, $logger);
+        if (!$skipBackup)
+            $backupOperation = $this->createBackupOperation($repo, $fileSystem, $logger);
+
         $optimizeOperation = $this->createOptimizeOperation($repo, $fileSystem, $logger);
 
-        $backupOperation->execute(...$ids);
+        if (!$skipBackup)
+            $backupOperation->execute(...$ids);
+
         $optimizeOperation->execute(...$ids);
     }
 


### PR DESCRIPTION
Hi, 
i added the 'skip-backup' parameter to the 'wp attachment' command to give the possibility to skip the generation of the backup file. This can be useful to those who need to optimize large numbers of files that already have an original copy.