### PR TITLE
Add support for php ^8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "psr/log": "^1.1",
         "spatie/image-optimizer": "^1.2",
         "symfony/filesystem": "^4.3 || ^5.0",


### PR DESCRIPTION
I'm using php 8.1.4 on my server and was unable to install this package because composer requires php 7.2 until < 8.0.0. Requiring ^8.0, I could successfully install it.